### PR TITLE
Handle older channels.http.AsgiRequest that uses a different attribute name for request.environ

### DIFF
--- a/req_stats/middleware.py
+++ b/req_stats/middleware.py
@@ -223,12 +223,7 @@ class RequestLoggingMiddleware:
 
 
     def parse_log(self, request, status_code):
-        try:
-            resp_env = request.__dict__["environ"]  # type: dict
-        except KeyError:
-            # Handle v2.x channels.http.AsgiRequest using a different key:
-            # https://github.com/django/channels/blob/2.4.0/channels/http.py#L61
-            resp_env = request.__dict__["META"]  # type: dict
+        resp_env = request.__dict__["META"]  # type: dict
         resolver_match = request.__dict__["resolver_match"]
         log_dict = {}
         log_dict.update(

--- a/req_stats/middleware.py
+++ b/req_stats/middleware.py
@@ -223,7 +223,12 @@ class RequestLoggingMiddleware:
 
 
     def parse_log(self, request, status_code):
-        resp_env = request.__dict__["environ"]  # type: dict
+        try:
+            resp_env = request.__dict__["environ"]  # type: dict
+        except KeyError:
+            # Handle v2.x channels.http.AsgiRequest using a different key:
+            # https://github.com/django/channels/blob/2.4.0/channels/http.py#L61
+            resp_env = request.__dict__["META"]  # type: dict
         resolver_match = request.__dict__["resolver_match"]
         log_dict = {}
         log_dict.update(


### PR DESCRIPTION
The channels.http.AsgiRequest uses `request.__dict__["META"]` instead of `request.__dict__["environ"]`. This gave me a `KeyError` when using the ASGI/Channels version 2.4.0 development server (aka `runserver` when `settings.ASGI_APPLICATION` is configured).

I don't know if you are interested in supporting this setup, but since it was such a small fix I though I'd mention it. 
Tested with Python 3.7.9, Django 3.2.14, channels 2.4.0 on Ubuntu 20.04.

Thanks for sharing the method, I am quite excited about these code stacks telling me where all those queries come from!